### PR TITLE
Performance improvements and search optimisation for select dropdowns

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: build
+    environment: production
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ storage/signups/*
 _ide_helper.php
 _ide_helper_models.php
 build/prod/db/*.sql
+build/*dev

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -245,9 +245,9 @@ class ResultsController extends Controller
 
     public function uploadResults()
     {
-        $season = Season::where('status', '<', 2)->get();
+        $season = Season::where('status', '<', 2)->get()->load('series');
         $points = Points::all();
-        $tracks = Circuit::select('id', 'name')->get();
+        $tracks = Circuit::select('id', 'name', 'series')->get()->load('series');
         $constructor = Constructor::select('id', 'name')->get();
         $driver = Driver::select('id', 'name')->get();
 

--- a/resources/views/standings/upload.blade.php
+++ b/resources/views/standings/upload.blade.php
@@ -435,9 +435,6 @@
                 value: 'DSQ'
             }
         ];
-
-        console.log(season)
-        console.log(tracks)
         
         $('#editScreen').addClass('hidden');
         $('#serverResponseScreen').addClass('hidden');

--- a/resources/views/standings/upload.blade.php
+++ b/resources/views/standings/upload.blade.php
@@ -435,6 +435,9 @@
                 value: 'DSQ'
             }
         ];
+
+        console.log(season)
+        console.log(tracks)
         
         $('#editScreen').addClass('hidden');
         $('#serverResponseScreen').addClass('hidden');
@@ -985,7 +988,7 @@
             let dispValue;
             
             for(let i = 0; i < selectInpFields[key].data.length; i++) {
-                dispValue = selectInpFields[key].data[i].name;
+                dispValue = `${selectInpFields[key].data[i].name} (${selectInpFields[key].data[i].series.code.toUpperCase()})`;
                 
                 if(selectInpFields[key].data[i].id !== selectInpFields[key].upload) {
                     select += `<option value=${selectInpFields[key].data[i].id}>${dispValue}</option>`;
@@ -1189,14 +1192,14 @@
 
         for(let y = 0; y < selectInpFields.driverID.originalData.length; y++) {
             if(selectInpFields.driverID.originalData[y].id === selectInpFields.driverID.upload) {
-                driverDispVal = selectInpFields.driverID.originalData[y].name;
+                driverDispVal = `${selectInpFields.driverID.originalData[y].name} (${selectInpFields.driverID.originalData[y].id})`;
                 driverSelect += `<option selected value=${selectInpFields.driverID.originalData[y].id}>${driverDispVal}</option>`;
             }
         }
 
         // Populate driver dropdown without the selected driver from the available drivers
         for(let x = 0; x < selectInpFields.driverID.data.length; x++) {
-            driverDispVal = selectInpFields.driverID.data[x].name;         
+            driverDispVal = `${selectInpFields.driverID.data[x].name} (${selectInpFields.driverID.data[x].id})`;         
             driverSelect += `<option value=${selectInpFields.driverID.data[x].id}>${driverDispVal}</option>`;
         }
 
@@ -1208,7 +1211,7 @@
         let constructorDispVal;
         
         for(let x = 0; x < selectInpFields.constructorID.data.length; x++) {
-            constructorDispVal = `${selectInpFields.constructorID.data[x].id} - ${selectInpFields.constructorID.data[x].name}`;
+            constructorDispVal = `${selectInpFields.constructorID.data[x].name} (${selectInpFields.constructorID.data[x].id})`;
 
             if(selectInpFields.constructorID.data[x].id !== selectInpFields.constructorID.upload) {
                 constructorSelect += `<option value=${selectInpFields.constructorID.data[x].id}>${constructorDispVal}</option>`;
@@ -1526,7 +1529,7 @@
             let constructorCol = document.getElementById(`constructorSelect${x}`);
 
             for(let y = 0; y < supportingVariables.availableConstructors.length; y++) {
-                constructorDispVal = `${supportingVariables.availableConstructors[y].id} - ${supportingVariables.availableConstructors[y].name}`;
+                constructorDispVal = `${supportingVariables.availableConstructors[y].name} (${supportingVariables.availableConstructors[y].id})`;
 
                 if(supportingVariables.availableConstructors[y].id !== json.results[x].constructor_id) {
                     constructorSelect += `<option value=${supportingVariables.availableConstructors[y].id}>${constructorDispVal}</option>`;
@@ -2040,13 +2043,13 @@
 
             for(let y = 0; y < driver.length; y++) {
                 if(driver[y].id === json.results[x].driver_id) {
-                    driverDispVal = driver[y].name;
+                    driverDispVal = `${driver[y].name} (${driver[y].id})`;
                     driverSelect += `<option selected value=${driver[y].id}>${driverDispVal}</option>`;
                 }
             }
 
             for(let y = 0; y < supportingVariables.availableDrivers.length; y++) {
-                driverDispVal = supportingVariables.availableDrivers[y].name;  
+                driverDispVal = `${supportingVariables.availableDrivers[y].name} (${supportingVariables.availableDrivers[y].id})`;  
                 driverSelect += `<option value=${supportingVariables.availableDrivers[y].id}>${driverDispVal}</option>`;
             }
 
@@ -3285,7 +3288,7 @@
             checkRaceTimeMatchesWithStatus(updatedJSONFromTable, jsonResultsDetailsStore, supportingVariables, i);
             checkAndMonitorResultsData(json, points, driver, supportingVariables.availableConstructors, status, regexValidationStrings, jsonTrackDetailsStore, jsonResultsDetailsStore, additionalDetailsStore, supportingVariables, i);
             serialiseRowReorderControls(jsonResultsDetailsStore, additionalDetailsStore, supportingVariables, i);
-            
+
             openResultsMoreDetailsOverlay(json, additionalDetailsStore, supportingVariables, i);
             
             checkGridValueGreaterThanArraySize(jsonResultsDetailsStore, supportingVariables);

--- a/resources/views/standings/upload.blade.php
+++ b/resources/views/standings/upload.blade.php
@@ -993,9 +993,9 @@
                 else {
                     select += `<option selected value=${selectInpFields[key].upload}>${dispValue}</option>`;
                 }
-                
-                selectInpFields[key].colId.innerHTML = select;
             }
+
+            selectInpFields[key].colId.innerHTML = select;
         });
     }
 
@@ -1198,8 +1198,9 @@
         for(let x = 0; x < selectInpFields.driverID.data.length; x++) {
             driverDispVal = selectInpFields.driverID.data[x].name;         
             driverSelect += `<option value=${selectInpFields.driverID.data[x].id}>${driverDispVal}</option>`;
-            selectInpFields.driverID.colId.innerHTML = driverSelect;
         }
+
+        selectInpFields.driverID.colId.innerHTML = driverSelect;
     }
 
     function populateConstructorDropdown(selectInpFields) {
@@ -1215,8 +1216,9 @@
             else {
                 constructorSelect += `<option selected value=${selectInpFields.constructorID.data[x].id}>${constructorDispVal}</option>`;
             }
-            selectInpFields.constructorID.colId.innerHTML = constructorSelect;
         }
+
+        selectInpFields.constructorID.colId.innerHTML = constructorSelect;
     }
 
     function populateStatusDropdown(selectInpFields) {
@@ -1232,8 +1234,9 @@
             else {
                 statusSelect += `<option selected value=${selectInpFields.status.data[x].id}>${statusDispVal}</option>`;
             }
-            selectInpFields.status.colId.innerHTML = statusSelect;
         }
+
+        selectInpFields.status.colId.innerHTML = statusSelect;
     }
 
     function reflectFastestLap(selectedValue, points, additionalDetailsStore, supportingVariables, i) {
@@ -1531,8 +1534,9 @@
                 else {
                     constructorSelect += `<option selected value=${supportingVariables.availableConstructors[y].id}>${constructorDispVal}</option>`;
                 }
-                constructorCol.innerHTML = constructorSelect;
             }
+            constructorCol.innerHTML = constructorSelect;
+
             constructorCol.dispatchEvent(e);
         }
     }
@@ -2019,7 +2023,7 @@
             dataToCheck.driverID.alertNode = `#errorDriverAlert${supportingVariables.indexPosMap[i] - 1}`;
 
             repopulateDriverResultsDropdowns(json, dataToCheck.driverID.allValues, supportingVariables);
-            
+
             checkDuplicateDiD(jsonResultsDetailsStore, supportingVariables);
             clearSelectWarning(dataToCheck.driverID.selectInpNode, dataToCheck.driverID.allValues, selectedValue, dataToCheck.driverID.parentNode, dataToCheck.driverID.alertNode);
             checkAllTableValuesForErrors(json, regexValidationStrings, jsonResultsDetailsStore, supportingVariables);
@@ -2044,8 +2048,9 @@
             for(let y = 0; y < supportingVariables.availableDrivers.length; y++) {
                 driverDispVal = supportingVariables.availableDrivers[y].name;  
                 driverSelect += `<option value=${supportingVariables.availableDrivers[y].id}>${driverDispVal}</option>`;
-                driverCol.innerHTML = driverSelect;
             }
+
+            driverCol.innerHTML = driverSelect;
         }
     }
 
@@ -3238,7 +3243,7 @@
             
             let i = json.results.length - 1;
 
-            updateResultsTable(json, points, driver, status, additionalDetailsStore, supportingVariables, i);            
+            updateResultsTable(json, points, driver, status, additionalDetailsStore, supportingVariables, i);
             
             supportingVariables.availableDrivers = driver.filter(ele => !jsonResultsDetailsStore.driverID.includes(ele.id));
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,7 +94,7 @@ Route::group(['middleware' => 'can:admin|coordinator'], function () {
      Route::get('/home/admin/user/{user}', 'DriverController@viewdetails')->name('coordinator.driverview');
      Route::get('/home/admin/user/edit/{user}', 'DriverController@viewedit')->name('coordinator.driveredit');
      Route::post('/home/admin/user/edit/save/{user}', 'DriverController@saveedit')->name('coordinator.driversave');
-     
+
      Route::get('/result/upload', 'ResultsController@uploadResults')->name('race.upload');
      Route::get('/result/{race}', 'ResultsController@fetchResultsByRaceId')->name('raceresults.id');
      Route::post('/results/race', 'ResultsController@saveRaceResults')->name('result.upload');


### PR DESCRIPTION
## What is the issue?
On selecting a different driver from the driver dropdown, the webpage takes a considerable amount of time to assign the selected driver in the field, freezing the webpage in the process.

A similiar instance of this issue was found while adding rows into the results table.
The solution found was exactly the same.

This causes unecessary delay in the workflow and a negative experience for the user.

## Troubleshooting Steps:
The approach taken to resolve this issue are as follows:
1. Identify the function being called on selection of a driver from the dropdown
1. Measure time taken for subsequent function calls within the wrapper function
1. Navigate to the function with significantly high call time and measure time for each operation
1. Reduce operation times and bring down the overall call time to acceptable range

### 1. Identifying function call on selection
On reviewing the call trace, it was found that `checkAndMonitorDriverId` was called when changing/selecting a driver from the dropdowns.

Within the above function, the 'change' event listener catches any changes made to the driver select field and carries out the job of reassigning current driver and repopulating all driver dropdowns.

Here are the function calls within the listener:

- Filter drivers.
- Repopulate all driver dropdowns.
- Check for duplicate driver selected.
- Check for invalid driver selection.
- Check for errors in all editable table cells.

### 2. Measuring call times of all functions within the wrapper
For measuring call times, `console.time(label)` was used before each function call to start the timer and `console.timeEnd(label)`, on the next line after the call.

Call times were measured after changing driver in position 1 to **The-Real-SD**, of race result with ID of **900**.

On measuring call times of all functions within the listener, the following results were seen:

    Listener total : 6467.94921875 ms
        - Filter : 0.035888671875 ms
        - Repopulation : 6429.35107421875 ms
        - Duplicate : 36.407958984375 ms
        - Warning : 0.1708984375 ms
        - Error : 1.417236328125 ms

From the above call times, it was clear that repopulating all driver dropdowns was taking too long, compared to other function calls.

### 3. Measuring time for each operation
Mentioned below are the main operations inside the targeted function:

- Running the check and repopulation of options for all dropdowns.
- Checking the presence of selected driver in the stored driver list and if present, assigning the driver as selected option.
- Repopulating options of the current dropdown with filtered available drivers list.

Measurement of operation times was done by inserting `console.time(label)` before the start of each code block, for each operation and `console.timeEnd(label)` after each block.

The following observations were made:

    Overall Call Time: 5842.717041015625 ms
        - Assigning current driver: 0.005126953125 ms
        - Repopulating all options: 900.987060546875 ms

### 4. Reducing operation time and subsequent call times
Looking through the code, it was noted that the assignment of all options into current driver select node was done incorrectly.

Instead of replacing the HTML content of the select node, at the end of the creation of the options list, the HTML content was changed on every addition to the options list. This meant that the options inside the driver dropdown, were changing as many times as there were drivers in the filtered available drivers list, which is highly time consuming.

Moving the content replacement after the options list creation bore the following call times:

    Overall Call Time: 6429.35107421875 ms
        - Assigning current driver: 0.017822265625 ms
        - Repopulating all options: 2.287841796875 ms

## Final Result:
A summarised call time improvement can be found below:

|  Wrapper Fn  |  Called Fn  |  Operation  |  Time Before(ms)  |  Time After(ms)  | 
|  :--------  |  :-------  |  :--------  |  -------:  |  --------:  |
|  Change Listener |    |    |  6467.94921875  |  58.427001953125  |
|    |  Filter  |    |  0.035888671875  |  0.065185546875  |
|    |  Repopulation  |    |  6429.35107421875  |  28.956787109375  |
|    |    |  Assigning current driver  |  0.005126953125  |  0.005126953125  |
|    |    |  Repopulating all options  |  900.987060546875  |  2.684814453125  |
|    |  Duplicate  |    |  36.407958984375  |  27.467041015625  |
|    |  Warning  |    |  0.1708984375  |  0.173095703125  |
|    |  Error  |    |  1.417236328125  |  0.89501953125  |

Through this change, the repopulation of all driver dropdowns take **99.55%** less time.